### PR TITLE
use single bond between ligand and complexed ion

### DIFF
--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -56,14 +56,20 @@ def is_transition_metal(atom):
     )
 
 
-def set_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
-    """convert some bonds to dative
+def set_single_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
+    """convert some bonds to single
 
     Replace any single bond between the dummy atom/transition metals and atoms
     with atomic numbers in fromAtoms with dative bonds.  This approach differs
     to the original approach[1] to highlight the denticity of every ligand.
 
+    Based on a discussion if dative bonds were a depreciated concept[2], and
+    because this script only provides depictions of formulae, out of RDKit's
+    bond types[3] type `SINGLE` is selected.
+
     [1] http://rdkit.org/docs/Cookbook.html#organometallics-with-dative-bonds
+    [2] https://github.com/rdkit/rdkit/discussions/6995
+    [3] https://www.rdkit.org/docs/cppapi/classRDKit_1_1Bond.html
 
     Returns the modified molecule.
 
@@ -82,7 +88,7 @@ def set_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
                 == Chem.BondType.SINGLE
             ):
                 rwmol.RemoveBond(nbr.GetIdx(), metal.GetIdx())
-                rwmol.AddBond(nbr.GetIdx(), metal.GetIdx(), Chem.BondType.DATIVE)
+                rwmol.AddBond(nbr.GetIdx(), metal.GetIdx(), Chem.BondType.SINGLE)
     return rwmol
 
 
@@ -96,7 +102,7 @@ def generate_previews(line):
         smiles = "*" + smiles
 
     mol = Chem.MolFromSmiles(smiles, sanitize=False)
-    mol = set_dative_bonds(mol)
+    mol = set_single_bonds(mol)
     svg = svgDepict(mol).replace("*", "")
 
     # save the SVG


### PR DESCRIPTION
This PR is not yet ready for a merge, and to be seen in conjunction with https://github.com/OpenChemistry/fragments/pull/18

Following a discussion on RDKit's user forum[1] if the concept of "dative bond" still is a good one, the script to build the formulae is edited; single bonds are used instead.  The other bond types provided by RDKit[2] do not appear better suitable.

[1] https://github.com/rdkit/rdkit/discussions/6995
[2] https://www.rdkit.org/docs/cppapi/classRDKit_1_1Bond.html