### PR TITLE
assign (R,S) labels to ligands' stereogenic centers

### DIFF
--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -9,6 +9,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.Chem.Draw import rdMolDraw2D
 from rdkit.Chem import rdDepictor
+from rdkit.Chem import rdCIPLabeler
 
 rdDepictor.SetPreferCoordGen(True)
 
@@ -28,6 +29,7 @@ def svgDepict(mol):
     metal_complex = Chem.Mol(mol.ToBinary())
     Chem.Kekulize(metal_complex)
     rdDepictor.Compute2DCoords(metal_complex)
+    rdCIPLabeler.AssignCIPLabels(metal_complex)
 
     # position of the "*" atom
     posStar = 0

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -99,9 +99,6 @@ def generate_previews(line):
     name = "_".join(line.split()[2:])
     print("Running", name)
 
-    if "*" not in smiles:
-        smiles = "*" + smiles
-
     mol = Chem.MolFromSmiles(smiles, sanitize=False)
     mol = reset_dative_bonds(mol)
     svg = svgDepict(mol).replace("*", "")

--- a/scripts/test_depict_ligands.smi
+++ b/scripts/test_depict_ligands.smi
@@ -7,4 +7,5 @@ C1=CC=C(C=C1)[C@@H](C(=O)O)O a (S)-mandelic_acid
 [C@@H]([C@H](C(=O)O)O)(C(=O)O)O a (R,R)-tataric_acid
 C[C@H]1N=C(CC2=N[C@H](C)CO2)OC1 a empty_RR_boxligand
 C[C@H]1N([Zn]N2=C(C3)OC[C@H]2C)=C3OC1 a (R,R)-Zn_box_complex
+C[C@H]1N([*]N2=C(C3)OC[C@H]2C)=C3OC1 a (R,R)-x_box_complex
 

--- a/scripts/test_depict_ligands.smi
+++ b/scripts/test_depict_ligands.smi
@@ -2,3 +2,9 @@ C1=CC2=CC3[N]4C(=CC=3)C=C3[N]5=C(C=C6[N]7C(=CC1=[N]2[*]457)C=C6)C=C3 a porphin
 *234[OH0]1CC[OH0]2CC[OH0]3CC[OH0]4CC1 m 12-crown-4
 some_SMILES_string # the_corresponding_name
 some other
+C1C[C@H](NC1)C(=O)O a (S)-prolin
+C1=CC=C(C=C1)[C@@H](C(=O)O)O a (S)-mandelic_acid
+[C@@H]([C@H](C(=O)O)O)(C(=O)O)O a (R,R)-tataric_acid
+C[C@H]1N=C(CC2=N[C@H](C)CO2)OC1 a empty_RR_boxligand
+C[C@H]1N([Zn]N2=C(C3)OC[C@H]2C)=C3OC1 a (R,R)-Zn_box_complex
+


### PR DESCRIPTION
As a result of the changes submitted, the stereogenic centers of the ligands are labeled; this is to close the issue reported earlier [here](https://github.com/OpenChemistry/fragments/issues/23).

The previously engaged approach to prepend the `*` placeholder if the SMILES string didn't report the dummy atom is dropped, because it affected (i.e., altered) the configuration of one of the amended test molecules.