### PR TITLE
docs(depict_ligands.py): consolidate a doc string

### DIFF
--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -59,21 +59,17 @@ def is_transition_metal(atom):
 
 
 def reset_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
-    """convert some bonds to dative
+    """edit some "dative bonds"
 
-    Replace any single bond between the dummy atom/transition metals and atoms
-    with atomic numbers in fromAtoms with dative bonds.  This approach differs
-    to the original approach[1] to highlight the denticity of every ligand.
-    Because of a discussion in the user forum of RDKit,[2] the use of a dative
-    bond indicated by an arrow however is dropped; because results are depicted
-    and are not starting point of additional computation, single bonds appear
-    a suitable alternative to use.
+    Bonds between atoms of transition metals typical donor atoms will be marked
+    as single bonds.  Initially inspired by the RDKit Cookbook[1] depicting an
+    example with pointy arrows, a subsequent discussion in RDKit's user forum[2]
+    convinced nbehrnd to drop this approach in favor of plain bonds.
 
     [1] http://rdkit.org/docs/Cookbook.html#organometallics-with-dative-bonds
     [2] https://github.com/rdkit/rdkit/discussions/6995
 
     Returns the modified molecule.
-
     """
     pt = Chem.GetPeriodicTable()
     rwmol = Chem.RWMol(mol)


### PR DESCRIPTION
The previous form of the doc string of function
reset_dative_bonds was not clear enough.