### PR TITLE
feat(depict_ligands.py) use argparse for file-based input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+# date: [2025-01-31 Fri]
+#
+# In contrast to the checks by code reformatter Black, the setup of this
+# git-precommit hook does not prevent a Python script to enter the commit
+# history even if flake8 identifies an issue (`--exit-zero`).  To use
+# this hook, resolve the dependencies (see `requirements-dev.txt`) and
+# update `.git/hooks/` by the command `pre-commit install`.
+#
+# Notes:
+#
+# - the installation creates the local folder `~/.cache/pre-commit` in
+#   addition of the virtual environment you explicitly set up
+# - while editing the Python scripts, `pre-commit run --all-files` allows
+#   to launch the tests separately and prior to e.g., `git add *.py`.
+#   Else, use `pre-commit run --files example.py` to check only one
+#   specific Python script of interest.
+# - if necessary, `git commit -m "commit message" --no-verify` allows to
+#   bypass the tests altogether.
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        name: "flake8 (advisory only, it does not block a commit)"
+        args:
+          - --max-line-length=90
+          - --show-source
+          - --statistics
+          - --count
+          - --exit-zero
+        verbose: true
+        always_run: true

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -66,15 +66,11 @@ def is_transition_metal(atom):
     """define transition metals by their atomic number
 
     For the purpose of a motif in the template library of ligands, the
-    dummy atom `*` equally should be processed as if it were a transition
-    metal.  By convention, its atomic number is 0."""
+    dummy atom indicated by `*` equally should be processed as if it
+    were a transition metal.  By convention, its atomic number is 0.
+    The pattern initially seen in RDKit's coockbook was edited."""
     n = atom.GetAtomicNum()
-    return (
-        (n >= 22 and n <= 29)
-        or (n >= 40 and n <= 47)
-        or (n >= 72 and n <= 79)
-        or (n == 0)
-    )
+    return (22 <= n <= 29) or (40 <= n <= 47) or (72 <= n <= 79) or (n == 0)
 
 
 def reset_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This script provides .svg and .png ligand template previews of Avogadro."""
 
+import argparse
 import sys
 
 import cairosvg
@@ -12,6 +13,25 @@ from rdkit.Chem import rdDepictor
 from rdkit.Chem import rdCIPLabeler
 
 rdDepictor.SetPreferCoordGen(True)
+
+
+def get_args():
+    """Get all command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="write .svg and .png ligand template previews for Avogadro",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "file",
+        help="one or multiple input file(s) to process",
+        metavar="FILE",
+        nargs="+",
+        type=argparse.FileType("rt"),
+    )
+
+    return parser.parse_args()
 
 
 def svgDepict(mol):
@@ -107,13 +127,11 @@ def generate_previews(line):
     cairosvg.svg2png(bytestring=svg, write_to=name + ".png")
 
 
-# repeat through all the files on the command-line
-# we can change this to use the glob module as well
-#  e.g., find all the files in a set of folders
-
-for argument in sys.argv[1:]:
-    # each of these files should have a bunch of SMILES
-    with open(argument, "r", encoding="utf8") as smiles_file:
+def main():
+    """join the functionalities"""
+    args = get_args()
+    smiles_files = args.file
+    for smiles_file in smiles_files:
         process_manually = []
         process_skipped = []
 
@@ -144,3 +162,7 @@ for argument in sys.argv[1:]:
         if process_skipped:
             print("\n\nentries commented out (`#`), or with an unknown label:")
             print(*(entry for entry in process_skipped), sep="\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -2,7 +2,6 @@
 """This script provides .svg and .png ligand template previews of Avogadro."""
 
 import argparse
-import sys
 
 import cairosvg
 
@@ -152,7 +151,7 @@ def main():
 
                 else:
                     process_skipped.append(line)
-            except:
+            except Exception:
                 print(f"error to process:\n{str(line).strip()}")
 
         if process_manually:

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -107,7 +107,7 @@ def reset_dative_bonds(mol):
 
 
 def generate_previews(line):
-    """provide .svg and .png previews of the currently processed structure"""
+    """provide per record a .svg and .png preview"""
     smiles = line.split()[0]
     name = "_".join(line.split()[2:])
     print("Running", name)
@@ -116,11 +116,9 @@ def generate_previews(line):
     mol = reset_dative_bonds(mol)
     svg = svgDepict(mol).replace("*", "")
 
-    # save the SVG
-    with open(name + ".svg", "w", encoding="utf8") as svg_file:
+    with open(name + ".svg", "w", encoding="utf-8") as svg_file:
         svg_file.write(svg)
 
-    # save a PNG
     cairosvg.svg2png(bytestring=svg, write_to=name + ".png")
 
 
@@ -153,11 +151,11 @@ def main():
                 print(f"error to process:\n{str(line).strip()}")
 
         if process_manually:
-            print("\n\nentries to be processed manually (label `m`):")
+            print("\nentries to be processed manually (label `m`):")
             print(*(entry for entry in process_manually), sep="\n")
 
         if process_skipped:
-            print("\n\nentries commented out (`#`), or with an unknown label:")
+            print("\nentries commented out (`#`), or with an unknown label:")
             print(*(entry for entry in process_skipped), sep="\n")
 
 

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -73,19 +73,21 @@ def is_transition_metal(atom):
     return (22 <= n <= 29) or (40 <= n <= 47) or (72 <= n <= 79) or (n == 0)
 
 
-def reset_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
+def reset_dative_bonds(mol):
     """edit some "dative bonds"
 
-    Bonds between atoms of transition metals typical donor atoms will be marked
-    as single bonds.  Initially inspired by the RDKit Cookbook[1] depicting an
-    example with pointy arrows, a subsequent discussion in RDKit's user forum[2]
-    convinced nbehrnd to drop this approach in favor of plain bonds.
+    Bonds between atoms of transition metals and typical Lewis base /
+    donor atoms will be marked as single bonds.  Initially the function
+    by the RDKit Cookbook[1] depicting an example with pointy arrows, a
+    subsequent discussion in RDKit's user forum[2] convinced nbehrnd to
+    drop this approach in favor of plain bonds.
 
     [1] http://rdkit.org/docs/Cookbook.html#organometallics-with-dative-bonds
     [2] https://github.com/rdkit/rdkit/discussions/6995
 
     Returns the modified molecule.
     """
+    from_atoms = [6, 7, 8, 15, 16]  # i.e., C, N, O, P, S
     pt = Chem.GetPeriodicTable()
     rwmol = Chem.RWMol(mol)
     rwmol.UpdatePropertyCache(strict=False)
@@ -93,7 +95,7 @@ def reset_dative_bonds(mol, fromAtoms=(6, 7, 8, 15, 16)):  # i.e., C, N, O, P, S
     for metal in metals:
         for nbr in metal.GetNeighbors():
             if (
-                nbr.GetAtomicNum() in fromAtoms
+                nbr.GetAtomicNum() in from_atoms
                 and rwmol.GetBondBetweenAtoms(
                     nbr.GetIdx(), metal.GetIdx()
                 ).GetBondType()

--- a/scripts/depict_ligands.py
+++ b/scripts/depict_ligands.py
@@ -38,7 +38,7 @@ def record_chopper(files_read):
 
     A valid report is a line to contain a SMILES string, a label, and
     the (chemical) name (later used to build the file name of the .svg
-    and .png preview); each separted from each other by white space."""
+    and .png preview); each separated from each other by white space."""
     temporary_content = []
     for file_read in files_read:
         temporary_content += file_read.readlines()
@@ -83,7 +83,7 @@ def is_transition_metal(atom):
     For the purpose of a motif in the template library of ligands, the
     dummy atom indicated by `*` equally should be processed as if it
     were a transition metal.  By convention, its atomic number is 0.
-    The pattern initially seen in RDKit's coockbook was edited."""
+    The pattern initially seen in RDKit's cookbook was edited."""
     n = atom.GetAtomicNum()
     return (22 <= n <= 29) or (40 <= n <= 47) or (72 <= n <= 79) or (n == 0)
 
@@ -159,11 +159,9 @@ def main():
                 process_skipped.append(record)
         except OSError:
             print(f"error to process {record}")
-        #        except IndexError as e:
-        #            print(f"'{e}' error in file '{smiles_file.name}'")
         except Exception as e:
             print(f"non-anticipated error: {e}")
-    #
+
     if process_manually:
         print("\nentries to be processed manually (label `m`):")
         print(*(entry for entry in process_manually), sep="\n")

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,0 +1,14 @@
+# This provides an optional environment to develop and check the Python
+# scripts by git pre-commit hooks.  See file `.pre-commit-config.yaml`
+# of this project for additional details.
+
+pre-commit
+black
+flake8
+
+# After completing the setup of your virtual environment, the command
+#
+#    pre-commit install
+#
+# updates your local `.git/hooks folder`.  You equally can launch the
+# checks without a commit by `git-precommit run --all-files`.


### PR DESCRIPTION
The access of files about (SMILES, labels, and names) to generate the previews of ligands now relies on Python's standard-library module argparse.